### PR TITLE
Fix unpacking under Linux

### DIFF
--- a/bbaLib/BbaArchive.cs
+++ b/bbaLib/BbaArchive.cs
@@ -247,6 +247,7 @@ namespace bbaLib
             foreach (BbaFile f in this)
             {
                 string path = Path.Combine(folder, f.InternalPath);
+                path = path.Replace("\\", Path.DirectorySeparatorChar.ToString());
                 Directory.CreateDirectory(Path.GetDirectoryName(path) ?? throw new ArgumentException("somehow path got messed up"));
                 using (FileStream w = new(path, FileMode.Create, FileAccess.Write))
                 {


### PR DESCRIPTION
This fixes unpacking a bba archive under Linux. Packaging a bba archive already works without problems.